### PR TITLE
NOJIRA Added env vars passed to travis to control compatibility and performance tests

### DIFF
--- a/trigger_java_cd_build.sh
+++ b/trigger_java_cd_build.sh
@@ -15,12 +15,16 @@ check_variable_is_set CF_DOMAIN
 VERSION=`cat version.properties | grep "previousVersion" | cut -d'=' -f2`
 APP_URL=${BINTRAY_ROOT_URL}/${APP_NAME}/${VERSION}/${APP_NAME}-${VERSION}.jar
 MANIFEST_URL=${BINTRAY_ROOT_URL}/${APP_NAME}-manifest/${VERSION}/${APP_NAME}-manifest-${VERSION}.jar
+RUN_COMPATIBILITY_TESTS=${RUN_COMPATIBILITY_TESTS:-false}
+RUN_PERFORMANCE_TESTS=${RUN_PERFORMANCE_TESTS:-true}
 
 REQUEST_BODY='{
   "request": {
     "branch": "master",
     "config": {
       "env": {
+        "RUN_COMPATIBILITY_TESTS": "'${RUN_COMPATIBILITY_TESTS}'",
+        "RUN_PERFORMANCE_TESTS": "'${RUN_PERFORMANCE_TESTS}'",
         "GITHUB_REPO_SLUG": "'${TRAVIS_REPO_SLUG}'",
         "APP_URL": "'${APP_URL}'",
         "MANIFEST_URL": "'${MANIFEST_URL}'",

--- a/trigger_node_cd_build.sh
+++ b/trigger_node_cd_build.sh
@@ -19,12 +19,16 @@ VERSION=$(sed -nE 's/^[ \\t]*"version": "([0-9]{1,}\.[0-9]{1,}\.[0-9x]{1,})",$/\
 #   The second ensures that we use the https variant if the repo was cloned using ssh.
 GIT_REPO_URL=$(git remote -v | grep fetch | grep origin | sed -nE 's/^origin\s(.*)\.git.*$/\1/p' | sed 's~git@github.com:~https://~')
 ZIP_URL="${GIT_REPO_URL}/archive/v${VERSION}.zip"
+RUN_COMPATIBILITY_TESTS=${RUN_COMPATIBILITY_TESTS:-true}
+RUN_PERFORMANCE_TESTS=${RUN_PERFORMANCE_TESTS:-true}
 
 REQUEST_BODY='{
   "request": {
     "branch": "master",
     "config": {
       "env": {
+        "RUN_COMPATIBILITY_TESTS": "'${RUN_COMPATIBILITY_TESTS}'",
+        "RUN_PERFORMANCE_TESTS": "'${RUN_PERFORMANCE_TESTS}'",
         "GITHUB_REPO_SLUG": "'${TRAVIS_REPO_SLUG}'",
         "ZIP_URL": "'${ZIP_URL}'",
         "APP_NAME": "'${APP_NAME}'",


### PR DESCRIPTION
Whether to run compatibility or performance tests can be controlled per project, defaulting to just running performance tests for java projects and both for node projects. The properties are to support an upcoming PR in continuous-delivery.