### PR TITLE
HTBHF-2297 Adding a network policy between the ui and the os places s…

### DIFF
--- a/network-policies.properties
+++ b/network-policies.properties
@@ -15,3 +15,4 @@ htbhf-claimant-service=htbhf-eligibility-service
 htbhf-claimant-service=htbhf-card-services-api
 htbhf-eligibility-service=htbhf-dwp-api
 htbhf-eligibility-service=htbhf-hmrc-api
+apply-for-healthy-start=htbhf-os-places-stub


### PR DESCRIPTION
- Adding a network policy between the ui and the os places stub
- We're doing this so that the UI can use an internal route rather than a public one, as requested by the PaaS team to help them with debugging.